### PR TITLE
Check for break outside of a loop but inside a label block.

### DIFF
--- a/src/NUglify.Tests/JavaScript/ControlFlow.cs
+++ b/src/NUglify.Tests/JavaScript/ControlFlow.cs
@@ -34,6 +34,18 @@ namespace NUglify.Tests.JavaScript
         }
 
         [Test]
+        public void BreakLabel()
+        {
+            TestHelper.Instance.RunTest();
+        }
+
+        [Test]
+        public void BreakNoLabel()
+        {
+            TestHelper.Instance.RunErrorTest("-ignore:JS1021", JSError.NoLabel, JSError.BadBreak);
+        }
+
+        [Test]
         public void Continue()
         {
             // don't optimize if(cond)continue;

--- a/src/NUglify.Tests/NUglify.Tests.csproj
+++ b/src/NUglify.Tests/NUglify.Tests.csproj
@@ -372,6 +372,12 @@
     <Content Include="TestData\Core\Input\SourceChange.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestData\JS\Expected\ControlFlow\BreakNoLabel.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\JS\Expected\ControlFlow\BreakLabel.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\HTML\tidy-html5-tests\html5\article.org.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -2670,6 +2676,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\JS\Input\ConditionalCompilation\StartWithSet.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\JS\Input\ControlFlow\BreakNoLabel.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\JS\Input\ControlFlow\BreakLabel.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\JS\Input\ControlFlow\Break.js">

--- a/src/NUglify.Tests/TestData/JS/Expected/ControlFlow/BreakLabel.js
+++ b/src/NUglify.Tests/TestData/JS/Expected/ControlFlow/BreakLabel.js
@@ -1,0 +1,1 @@
+outer_block:{console.log("1");break outer_block}

--- a/src/NUglify.Tests/TestData/JS/Expected/ControlFlow/BreakNoLabel.js
+++ b/src/NUglify.Tests/TestData/JS/Expected/ControlFlow/BreakNoLabel.js
@@ -1,0 +1,1 @@
+console.log("1");break

--- a/src/NUglify.Tests/TestData/JS/Input/ControlFlow/BreakLabel.js
+++ b/src/NUglify.Tests/TestData/JS/Input/ControlFlow/BreakLabel.js
@@ -1,0 +1,5 @@
+outer_block: {
+  console.log('1');
+  break outer_block; // breaks out of both inner_block and outer_block
+  console.log(':-('); // skipped
+}

--- a/src/NUglify.Tests/TestData/JS/Input/ControlFlow/BreakNoLabel.js
+++ b/src/NUglify.Tests/TestData/JS/Input/ControlFlow/BreakNoLabel.js
@@ -1,0 +1,5 @@
+outer_block: {
+  console.log('1');
+  break inner_block; // no such label
+  console.log(':-('); // skipped
+}

--- a/src/NUglify/JavaScript/Visitors/AnalyzeNodeVisitor.cs
+++ b/src/NUglify/JavaScript/Visitors/AnalyzeNodeVisitor.cs
@@ -1587,7 +1587,8 @@ namespace NUglify.JavaScript.Visitors
                     node.Label = null;
                 }
 
-                if (!IsInsideLoop(node, true))
+                // check the break is inside a loop or in a label block
+                if (!IsInsideLoop(node, true) && (node.Label == null || !IsInsideLabel(node, node.Label)))
                 {
                     node.Context.HandleError(JSError.BadBreak, true);
                 }
@@ -4415,6 +4416,28 @@ namespace NUglify.JavaScript.Visitors
 
             // if we get here, we're not in a loop
             return insideLoop;
+        }
+
+        private static bool IsInsideLabel(AstNode node, string label)
+        {
+            // assume we are not
+            var insideLabel = false;
+
+            // go up until we get to the top or we get to a function object
+            while (node != null && !(node is FunctionObject))
+            {
+                if (node is LabeledStatement && string.Compare(((LabeledStatement)node).Label, label) == 0)
+                {
+                    // we have a matching label
+                    return true;
+                }
+
+                // go up the tree
+                node = node.Parent;
+            }
+
+            // if we get here, we're not in a nested label
+            return insideLabel;
         }
 
         private static AstNode ReplaceCultureValue(ConstantWrapper node)


### PR DESCRIPTION
Break is allowed outside of a loop if it is inside a named label. Currently the check is too restrictive.

e.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break
```
outer_block: {
  inner_block: {
    console.log('1');
    break outer_block; // breaks out of both inner_block and outer_block
    console.log(':-('); // skipped
  }
  console.log('2'); // skipped
}

```

This is causing errors in the Visual Studio bundle extension, https://github.com/madskristensen/BundlerMinifier.