### PR TITLE
Respect self-closing tags with "RemoveOptionalTags" option disabled

### DIFF
--- a/src/NUglify.Tests/Html/TestCollapseWhiteSpaces.cs
+++ b/src/NUglify.Tests/Html/TestCollapseWhiteSpaces.cs
@@ -207,10 +207,10 @@ namespace NUglify.Tests.Html
                 equal(minify(input), output);
             });
 
-            equal(minify("<p>foo <img> bar</p>", disableRemoveOptTag), "<p>foo <img> bar</p>");
-            equal(minify("<p>foo<img>bar</p>", disableRemoveOptTag), "<p>foo<img>bar</p>");
-            equal(minify("<p>foo <img>bar</p>", disableRemoveOptTag), "<p>foo <img>bar</p>");
-            equal(minify("<p>foo<img> bar</p>", disableRemoveOptTag), "<p>foo<img> bar</p>");
+            equal(minify("<p>foo <img> bar</p>", disableRemoveOptTag), "<p>foo <img /> bar</p>");
+            equal(minify("<p>foo<img>bar</p>", disableRemoveOptTag), "<p>foo<img />bar</p>");
+            equal(minify("<p>foo <img>bar</p>", disableRemoveOptTag), "<p>foo <img />bar</p>");
+            equal(minify("<p>foo<img> bar</p>", disableRemoveOptTag), "<p>foo<img /> bar</p>");
             equal(minify("<p>  <a href=\"#\">  <code>foo</code></a> bar</p>", disableRemoveOptTag), "<p><a href=#><code>foo</code></a> bar</p>");
             equal(minify("<p><a href=\"#\"><code>foo</code></a> bar</p>", disableRemoveOptTag), "<p><a href=#><code>foo</code></a> bar</p>");
             equal(minify("<p>  <a href=\"#\">  <code>   foo</code></a> bar   </p>", disableRemoveOptTag), "<p><a href=#><code>foo</code></a> bar</p>");

--- a/src/NUglify.Tests/Html/TestOptionalTags.cs
+++ b/src/NUglify.Tests/Html/TestOptionalTags.cs
@@ -83,5 +83,37 @@ namespace NUglify.Tests.Html
             output = @"<table><tbody><tr><td><span>A</span></td><td><span>B</span></td><td><span>C</span></td></tr><tr><td><span>A</span></td><td><span>B</span></td><td><span>C</span></td></tr></tbody></table>";
             equal(minify(input, new HtmlSettings() {RemoveOptionalTags = false, IsFragmentOnly = true}), output);
         }
+
+        [Test]
+        public void TestSelfClosingTagWithOptionalTags()
+        {
+            var settings = new HtmlSettings()
+            {
+                IsFragmentOnly = true,
+                RemoveOptionalTags = false,
+                RemoveQuotedAttributes = false
+            };
+
+            input = "<link rel=\"stylesheet\" href=\"style.css\" />";
+            output = "<link rel=\"stylesheet\" href=\"style.css\" />";
+
+            equal(minify(input, settings), output);
+        }
+
+        [Test]
+        public void TestSelfClosingTagWithoutOptionalTags()
+        {
+            var settings = new HtmlSettings()
+            {
+                IsFragmentOnly = true,
+                RemoveOptionalTags = true,
+                RemoveQuotedAttributes = false
+            };
+
+            input = "<link rel=\"stylesheet\" href=\"style.css\" />";
+            output = "<link rel=\"stylesheet\" href=\"style.css\">";
+
+            equal(minify(input, settings), output);
+        }
     }
 }

--- a/src/NUglify/Html/HtmlWriterBase.cs
+++ b/src/NUglify/Html/HtmlWriterBase.cs
@@ -8,7 +8,7 @@ namespace NUglify.Html
 {
     public abstract class HtmlWriterBase
     {
-        private int xmlNamespaceLevel;
+        protected int XmlNamespaceLevel { get; private set; }
 
         protected HtmlWriterBase()
         {
@@ -73,14 +73,14 @@ namespace NUglify.Html
 
             if (isInXml)
             {
-                xmlNamespaceLevel++;
+                XmlNamespaceLevel++;
             }
 
             WriteChildren(node);
 
             if (isInXml)
             {
-                xmlNamespaceLevel--;
+                XmlNamespaceLevel--;
             }
 
             if (shouldClose)
@@ -120,7 +120,7 @@ namespace NUglify.Html
                 Write("?");
             }
 
-            if ((node.Kind & ElementKind.SelfClosing) != 0 && xmlNamespaceLevel > 0)
+            if ((node.Kind & ElementKind.SelfClosing) != 0 && XmlNamespaceLevel > 0)
             {
                 Write(" /");
             }

--- a/src/NUglify/Html/HtmlWriterToHtml.cs
+++ b/src/NUglify/Html/HtmlWriterToHtml.cs
@@ -67,7 +67,36 @@ namespace NUglify.Html
                 lastNewLine = true;
             }
 
-            base.WriteStartTag(node);
+            Write("<");
+            var isProcessing = (node.Kind & ElementKind.ProcessingInstruction) != 0;
+            if (isProcessing)
+            {
+                Write("?");
+            }
+            Write(node.Name);
+
+            if (node.Attributes != null)
+            {
+                var count = node.Attributes.Count;
+                for (int i = 0; i < count; i++)
+                {
+                    var attribute = node.Attributes[i];
+                    Write(" ");
+                    WriteAttribute(node, attribute, i + 1 == count);
+                }
+            }
+
+            if (isProcessing)
+            {
+                Write("?");
+            }
+
+            if ((node.Kind & ElementKind.SelfClosing) != 0 && (XmlNamespaceLevel > 0 || !settings.RemoveOptionalTags))
+            {
+                Write(" /");
+            }
+
+            Write(">");
 
             if (shouldPretty)
             {


### PR DESCRIPTION
Respect self-closing tags with `RemoveOptionalTags` option disabled.

**Case 1 (`RemoveOptionalTags` is `false`):**

Input: ```<link rel="stylesheet" href="style.css" />```
Output: ```<link rel="stylesheet" href="style.css" />```

**Case 2 (`RemoveOptionalTags` is `true`):**

Input: ```<link rel="stylesheet" href="style.css" />```
Output: ```<link rel="stylesheet" href="style.css">```