### PR TITLE
Tests for when arrow function returns object literal.

### DIFF
--- a/src/NUglify.Tests/Core/ArrowLiteral.cs
+++ b/src/NUglify.Tests/Core/ArrowLiteral.cs
@@ -1,0 +1,24 @@
+﻿using NUglify.JavaScript;
+using NUglify.JavaScript.Visitors;
+using NUnit.Framework;
+
+namespace NUglify.Tests.Core
+{
+    [TestFixture]
+    public class ArrowLiteral
+    {
+        [Test]
+        public void LiteralCore()
+        {
+            var source = "var arrow = n => { return { x: n + 1, y: n - 1 }; };";
+            var expected = "var arrow=n=>{return{x:n+1,y:n-1}}";
+            var settings = new CodeSettings();
+            var parser = new JSParser();
+            var code = parser.Parse(source, settings);
+
+            var minified = OutputVisitor.Apply(code, settings);
+
+            Assert.AreEqual(expected, minified);
+        }
+    }
+}

--- a/src/NUglify.Tests/JavaScript/BlockOpts.cs
+++ b/src/NUglify.Tests/JavaScript/BlockOpts.cs
@@ -129,6 +129,12 @@ namespace NUglify.Tests.JavaScript
         }
 
         [Test]
+        public void ReturnLiteral()
+        {
+            TestHelper.Instance.RunTest();
+        }
+
+        [Test]
         public void ExprReturn()
         {
             TestHelper.Instance.RunTest();

--- a/src/NUglify.Tests/NUglify.Tests.csproj
+++ b/src/NUglify.Tests/NUglify.Tests.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Core\ArrowConcise.cs" />
+    <Compile Include="Core\ArrowLiteral.cs" />
     <Compile Include="Core\CommandLine.cs" />
     <Compile Include="Core\CssEncoding.cs" />
     <Compile Include="Core\DebugBlock.cs" />
@@ -382,6 +383,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\CSS\Input\Selectors\Bootstrap4CssVariables.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\JS\Expected\BlockOpts\ReturnLiteral.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\JS\Expected\ControlFlow\BreakNoLabel.js">
@@ -2411,6 +2415,9 @@
     <Content Include="TestData\JS\Input\AstMods\opAssignCombine.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestData\JS\Input\BlockOpts\ReturnLiteral.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\JS\Input\Classes\ClassDecl.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -3371,6 +3378,9 @@
       <Project>{6ed835a6-8a8a-44ec-8679-7ebbe2a0dbe4}</Project>
       <Name>NUglifyApp</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildThisFileDirectory)..\NUglify.shared.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NUglify.Tests/TestData/JS/Expected/BlockOpts/ReturnLiteral.js
+++ b/src/NUglify.Tests/TestData/JS/Expected/BlockOpts/ReturnLiteral.js
@@ -1,0 +1,1 @@
+﻿function test1(a){return{x:a+1,y:a-1}}function test2(a){return{a}}

--- a/src/NUglify.Tests/TestData/JS/Input/BlockOpts/ReturnLiteral.js
+++ b/src/NUglify.Tests/TestData/JS/Input/BlockOpts/ReturnLiteral.js
@@ -1,0 +1,13 @@
+﻿function test1(a)
+{
+    return { x: a + 1, y: a - 1 };
+}
+
+function test2(a)
+{
+    // ES2015 Object initializer
+    return {
+        a
+    };
+}
+

--- a/src/NUglify/JavaScript/Visitors/OutputVisitor.cs
+++ b/src/NUglify/JavaScript/Visitors/OutputVisitor.cs
@@ -3871,7 +3871,16 @@ namespace NUglify.JavaScript.Visitors
                 {
                     // the arrow function body has only one "statement" and it's not a return.
                     // assume it's a concise expression body and just output it
+                    var isLiteral = node.Body[0].GetType() == typeof(ObjectLiteral);
+                    if (isLiteral)
+                    {
+                        Output("{return");
+                    }
                     node.Body[0].Accept(this);
+                    if (isLiteral)
+                    {
+                        Output("}");
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Hi

I've made a small change to see if I could get it to handle arrow functions that return object literals.

Not sure if I've done this correctly, so let me know if this should be handled some other way.

Should fix #43 (as well as https://github.com/madskristensen/BundlerMinifier/issues/301)