### PR TITLE
Fixes issue with async arrow function without parameters

### DIFF
--- a/src/NUglify.Tests/TestData/JS/Expected/ES2017/AsyncArrowFunction.js
+++ b/src/NUglify.Tests/TestData/JS/Expected/ES2017/AsyncArrowFunction.js
@@ -1,1 +1,1 @@
-﻿const object={doSomething:test=>"done"+test,doSomethingAsync:async url=>await fetch(url)};object.doSomethingAsync()
+﻿const object={regularFunction:test=>"done"+test,asyncArrowFunctionWithoutParameters:async()=>await fetch("someurl"),asyncArrowFunctionWithParameters:async url=>await fetch(url)};object.doSomethingAsync()

--- a/src/NUglify.Tests/TestData/JS/Input/ES2017/AsyncArrowFunction.js
+++ b/src/NUglify.Tests/TestData/JS/Input/ES2017/AsyncArrowFunction.js
@@ -1,8 +1,11 @@
 ﻿const object = {
-    doSomething: (test) => {
+    regularFunction: (test) => {
         return "done" + test;
     },
-    doSomethingAsync: async (url) => {
+    asyncArrowFunctionWithoutParameters: async () => {
+        return await fetch("someurl");
+    },
+    asyncArrowFunctionWithParameters: async (url) => {
         return await fetch(url);
     }
 }

--- a/src/NUglify/JavaScript/JSParser.cs
+++ b/src/NUglify/JavaScript/JSParser.cs
@@ -3967,6 +3967,7 @@ namespace NUglify.JavaScript
                 case JSToken.LeftParenthesis:
                     {
                         var leftParen = m_currentToken.Clone();
+                        var parentAst = ast;
                         GetNextToken();
                         if (m_currentToken.Is(JSToken.For))
                         {
@@ -4035,8 +4036,7 @@ namespace NUglify.JavaScript
                                 {
                                     ast = new GroupingOperator(leftParen)
                                         {
-                                            Operand = operand,
-                                            Parent = ast
+                                            Operand = operand
                                         };
                                     ast.UpdateWith(operand.Context);
 
@@ -4052,6 +4052,8 @@ namespace NUglify.JavaScript
                                     }
                                 }
                             }
+
+                            ast.Parent = parentAst;
                         }
                     }
                     break;


### PR DESCRIPTION
Fix issue where the async identifier is lost when minifying an async arrow function without parameters.

Part of #77 