### PR TITLE
Fixs #93

### DIFF
--- a/src/NUglify.Tests/Html/TestCollapseWhiteSpaces.cs
+++ b/src/NUglify.Tests/Html/TestCollapseWhiteSpaces.cs
@@ -98,6 +98,13 @@ namespace NUglify.Tests.Html
         }
 
         [Test]
+        public void TestTextareaPreserveNewLine()
+        {
+            var settings = new HtmlSettings();
+            equal(minify("\n<label>Text</label>\n    <textarea>   Line1   \n    Line2   </textarea>", settings), "<label>Text</label><textarea>   Line1   \n    Line2   </textarea>");
+        }
+
+        [Test]
         public void SpaceNormalizationAroundText()
         {
             // Copyright(c) 2010 - 2016 Juriy "kangax" Zaytsev

--- a/src/NUglify/Html/HtmlMinifier.cs
+++ b/src/NUglify/Html/HtmlMinifier.cs
@@ -130,7 +130,7 @@ namespace NUglify.Html
             foreach (var subNode in node.Children)
             {
                 ProcessNode(subNode);
-            }            
+            }
         }
 
         private void TrimNodeOnStart(HtmlNode node)
@@ -166,6 +166,12 @@ namespace NUglify.Html
             if (settings.RemoveJavaScript && node is HtmlElement && ((HtmlElement) node).Descriptor?.Name == "script")
             {
                 node.Remove();
+            }
+
+            // If current node requires preserving formatting inside it we need to trim all pending text node that we collected before
+            if (settings.CollapseWhitespaces && node is HtmlElement && settings.TagsWithNonCollapsableWhitespaces.ContainsKey(((HtmlElement) node).Descriptor?.Name))
+            {
+                TrimPendingTextNodes();
             }
         }
 

--- a/src/NUglify/Html/HtmlMinifier.cs
+++ b/src/NUglify/Html/HtmlMinifier.cs
@@ -169,7 +169,8 @@ namespace NUglify.Html
             }
 
             // If current node requires preserving formatting inside it we need to trim all pending text node that we collected before
-            if (settings.CollapseWhitespaces && node is HtmlElement && settings.TagsWithNonCollapsableWhitespaces.ContainsKey(((HtmlElement) node).Descriptor?.Name))
+            var nodeName = node is HtmlElement ? ((HtmlElement) node).Name : null;
+            if (settings.CollapseWhitespaces && !string.IsNullOrEmpty(nodeName) && settings.TagsWithNonCollapsableWhitespaces.ContainsKey(nodeName))
             {
                 TrimPendingTextNodes();
             }


### PR DESCRIPTION
Fixes #93 

Fix is simple, if we current node requires preserving formatting inside it (like "textarea" or "pre" tags) we have to clear all pending text nodes before we start working with this tag. If we don't do it before, `pendingTagNonCollapsibleWithSpaces` variable will be not 0 and pending text nodes won't be cleared in `TrimNodeOnEnd -> TrimPendingTextNodes`.

Thanks